### PR TITLE
Fix incorrect parsing of `created_at` timestamp

### DIFF
--- a/inc/Print.php
+++ b/inc/Print.php
@@ -728,7 +728,7 @@ class P
 
 			echo '<tr>
 			<td>Cheated score last detected at (dd/mm/yyyy)</td>
-			<td>' . (($lastScoreDetection && $lastScoreDetection['created_at']) ? date('d/m/Y', $lastScoreDetection['created_at']) : 'Never') . '</td>
+			<td>' . (($lastScoreDetection && $lastScoreDetection['created_at']) ? new DateTime($lastScoreDetection['created_at'])->format('d/m/Y') : 'Never') . '</td>
 			</tr>';
 
 			echo '<tr class="single-row">


### PR DESCRIPTION
`date` expects a UNIX timestamp, oops.