### PR TITLE
Use self-hosted VPC runner for deployments

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   production-deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, vpc]
 
     steps:
       - name: Check out latest commit


### PR DESCRIPTION
Switch from GitHub-hosted runners to self-hosted VPC runner for K8s deployments.

This is required because the K8s API is now only accessible from within the VPC.