### PR TITLE
Add health endpoint and HTTP readiness probe

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -9,7 +9,8 @@ apps:
         tag: latest
       port: 80
       readinessProbe:
-        tcpSocket:
+        httpGet:
+          path: /_health
           port: 80
         initialDelaySeconds: 5
         periodSeconds: 10

--- a/index.php
+++ b/index.php
@@ -1,4 +1,11 @@
 <?php
+// Health check endpoint for Kubernetes probes
+if ($_SERVER['REQUEST_URI'] === '/_health') {
+	http_response_code(200);
+	echo 'ok';
+	exit;
+}
+
 // Get functions
 require_once './inc/functions.php';
 // Frontend stuff


### PR DESCRIPTION
## Summary
- Add `/_health` endpoint in PHP that returns 200 OK
- Switch readiness probe from TCP to HTTP for proper health checking
- Required for Kyverno policy compliance (require-probes)

## Test plan
- [ ] Verify `/_health` endpoint returns 200 OK
- [ ] Verify readiness probe works in Kubernetes

🤖 Generated with [Claude Code](https://claude.com/claude-code)