### PR TITLE
add missing break after restrictUnrestrictUserReason

### DIFF
--- a/submit.php
+++ b/submit.php
@@ -66,6 +66,7 @@ try {
 		case 'restrictUnrestrictUserReason':
 			sessionCheckAdmin(Privileges::AdminBanUsers);
 			D::RestrictUnrestrictUserReason();
+			break;
 		case 'banUnbanUserReason':
 			sessionCheckAdmin(Privileges::AdminBanUsers);
 			D::BanUnbanUserReason();


### PR DESCRIPTION
Fixes #67

Without the break, restrict falls through into ban/unban.