### PR TITLE
Show IP last-used timestamps

### DIFF
--- a/api/get_ip_country.php
+++ b/api/get_ip_country.php
@@ -1,0 +1,17 @@
+<?php
+require_once '../inc/functions.php';
+
+startSessionIfNotStarted();
+sessionCheckAdmin(Privileges::AdminManagePrivileges);
+
+header('Content-Type: text/plain; charset=utf-8');
+
+if (!isset($_GET['ip']) || !filter_var($_GET['ip'], FILTER_VALIDATE_IP)) {
+	http_response_code(400);
+	die('dunno');
+}
+
+$ip = $_GET['ip'];
+$country = trim((string) get_contents_http('https://ip.zxq.co/' . rawurlencode($ip) . '/country'));
+
+echo preg_match('/^[A-Z]{2}$/', $country) ? $country : 'dunno';

--- a/inc/Print.php
+++ b/inc/Print.php
@@ -600,7 +600,7 @@ class P
 			// Get user data
 			$userData = $GLOBALS['db']->fetch('SELECT * FROM users WHERE id = ? LIMIT 1', $_GET['id']);
 			$lastScoreDetection = $GLOBALS['db']->fetch('SELECT created_at FROM score_detections WHERE user_id = ? ORDER BY created_at DESC LIMIT 1', $_GET['id']);
-			$ips = $GLOBALS['db']->fetchAll('SELECT ip, occurencies FROM ip_user WHERE userid = ? ORDER BY occurencies DESC LIMIT 50', $_GET['id']);
+			$ips = $GLOBALS['db']->fetchAll('SELECT ip, occurencies, last_used_at FROM ip_user WHERE userid = ? ORDER BY occurencies DESC LIMIT 50', $_GET['id']);
 			// Check if this user exists
 			if (!$userData) {
 				throw new Exception("That user doesn't exist");
@@ -954,7 +954,8 @@ class P
 				echo '</td><td><ul>';
 
 				foreach ($ips as $ip) {
-					echo "<li>$ip[ip] <a class='getcountry' data-ip='$ip[ip]' title='Click to retrieve IP country'>(?)</a> ($ip[occurencies])</li>";
+					$lastUsedAt = $ip['last_used_at'] ? date('Y-m-d H:i', strtotime($ip['last_used_at'])) : 'Unknown';
+					echo "<li>$ip[ip] <a class='getcountry' data-ip='$ip[ip]' title='Click to retrieve IP country'>(?)</a> ($ip[occurencies], last used $lastUsedAt)</li>";
 				}
 			}
 			echo '</ul></td></tr>';
@@ -3190,6 +3191,7 @@ class P
 				<th>User</th>
 				<th>Privileges</th>
 				<th>Occurrencies</th>
+				<th>Last Used</th>
 			</tr>
 			</thead>';
 			echo '<tbody>';
@@ -3209,18 +3211,20 @@ class P
 				if ($userFilter && $row["userid"] != $_GET["uid"]) {
 					$hax = true;
 				}
+				$lastUsedAt = $row['last_used_at'] ? date('Y-m-d H:i', strtotime($row['last_used_at'])) : 'Unknown';
 				echo "<tr class='" . ($userFilter && $row["userid"] != $_GET["uid"] ? "danger bold" : "") . "'>
 				<td>$row[ip] <a class='getcountry' data-ip='$row[ip]'>(?)</a></td>
 				<td><a href='index.php?p=103&id=$row[userid]' target='_blank'>$row[username]</a> <i>($row[userid])</i></td>
 				<td><span class='label label-$groupColor'>$groupText</span></td>
 				<td>$row[occurencies]</td>
+				<td>$lastUsedAt</td>
 				</tr>";
 			}
 
 			if ($userFilter && !$hax) {
-				echo '<td class="success" style="text-align: center" colspan=4><i class="fa fa-thumbs-up"></i>	<b>Looking good!</b></td>';
+				echo '<td class="success" style="text-align: center" colspan=5><i class="fa fa-thumbs-up"></i>	<b>Looking good!</b></td>';
 			} else if ($userFilter) {
-				echo '<td class="warning" style="text-align: center" colspan=4><i class="fa fa-warning"></i>	<b>Ohoh, opsie wopsie!</b></td>';
+				echo '<td class="warning" style="text-align: center" colspan=5><i class="fa fa-warning"></i>	<b>Ohoh, opsie wopsie!</b></td>';
 			}
 
 			echo '</tbody>

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -536,9 +536,9 @@ function getUserCountry()
 		return 'XX'; // Return XX if $ip isn't valid.
 	}
 	// otherwise, retrieve the contents from ip.zxq.co's API
-	$data = get_contents_http("http://ip.vanilla.rocks/$ip/country");
+	$data = get_contents_http("https://ip.zxq.co/" . rawurlencode($ip) . "/country");
 	// And return the country. If it's set, that is.
-	return strlen($data) == 2 ? $data : 'XX';
+	return strlen((string) $data) == 2 ? $data : 'XX';
 }
 // updateUserCountry updates the user's country in the database with the country they
 // are currently connecting from.
@@ -1207,8 +1207,8 @@ function logIP($uid)
 {
 	// botnet-track IP
 	$GLOBALS['db']->execute(
-		"INSERT INTO ip_user (userid, ip, occurencies) VALUES (?, ?, '1')
-							ON DUPLICATE KEY UPDATE occurencies = occurencies + 1",
+		"INSERT INTO ip_user (userid, ip, occurencies, last_used_at) VALUES (?, ?, '1', NOW())
+							ON DUPLICATE KEY UPDATE occurencies = occurencies + 1, last_used_at = NOW()",
 		[$uid, getIP()]
 	);
 }

--- a/index.php
+++ b/index.php
@@ -270,7 +270,7 @@ if (isset($_GET['p'])) {
 
 		$(".getcountry").click(function() {
 			var i = $(this);
-			$.get("https://ip.zxq.co/" + $(this).data("ip") + "/country", function(data) {
+			$.get("api/get_ip_country.php", {ip: $(this).data("ip")}, function(data) {
 				data = (data === "" ? "dunno" : data);
 				i.text("(" + data + ")");
 			});


### PR DESCRIPTION
## Summary
- replace the country-only IP lookup with a lazy-loaded proxycheck.io IP intelligence endpoint
- show country, network type, proxy/VPN/Tor flags, and risk when an admin clicks the existing (?) link
- use API-style JSON auth errors instead of page redirects, avoiding /api/index.php redirect/404 failures
- show last-used timestamps for top user IPs and IP search results when available

## Notes
- existing ip_user rows will show Unknown until the new last_used_at column is populated by future logins
- PROXYCHECK_API_KEY is optional; set it in env/vault to use the registered free-tier quota

## Verification
- php -l api/get_ip_info.php
- php -l inc/functions.php
- php -l inc/Print.php
- php -l index.php
- git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check
- curl -sS --max-time 10 https://proxycheck.io/v3/108.162.242.16

## Rollout
Merge/deploy after osuAkatsuki/mysql-database#37 and the relevant writer deploys that populate ip_user.last_used_at.