### PR TITLE
Allow admins to unlink connected profiles

### DIFF
--- a/inc/Do.php
+++ b/inc/Do.php
@@ -631,11 +631,35 @@ class D
 		}
 	}
 
+	private static function connectionLinkDefinitions()
+	{
+		return [
+			'discord' => [
+				'label' => 'Discord',
+				'idColumn' => 'discord_account_id',
+				'selectColumns' => 'username, discord_account_id',
+				'updateSql' => 'UPDATE users SET discord_account_id = NULL WHERE id = ? LIMIT 1',
+			],
+			'twitch' => [
+				'label' => 'Twitch',
+				'idColumn' => 'twitch_account_id',
+				'selectColumns' => 'username, twitch_account_id',
+				'updateSql' => 'UPDATE users SET twitch_account_id = NULL, twitch_username = NULL WHERE id = ? LIMIT 1',
+			],
+			'osu' => [
+				'label' => 'osu!',
+				'idColumn' => 'official_osu_user_id',
+				'selectColumns' => 'username, official_osu_user_id',
+				'updateSql' => 'UPDATE users SET official_osu_user_id = NULL, official_osu_username = NULL WHERE id = ? LIMIT 1',
+			],
+		];
+	}
+
 	/*
-	 * ResetDiscordLink
-	 * Reset someone's Discord link (ADMIN CP)
+	 * ResetConnectionLink
+	 * Reset someone's connected profile link (ADMIN CP)
 	 */
-	public static function ResetDiscordLink()
+	public static function ResetConnectionLink()
 	{
 		try {
 			// Check if everything is set
@@ -643,25 +667,36 @@ class D
 				throw new Exception('Invalid request');
 			}
 
-			// Get user data to check if they have a Discord link
-			$userData = $GLOBALS['db']->fetch('SELECT username, discord_account_id FROM users WHERE id = ? LIMIT 1', [$_GET['id']]);
+			if (!isset($_GET['provider']) || empty($_GET['provider'])) {
+				throw new Exception('Invalid connection provider');
+			}
+
+			$definitions = self::connectionLinkDefinitions();
+			if (!isset($definitions[$_GET['provider']])) {
+				throw new Exception('Invalid connection provider');
+			}
+
+			$definition = $definitions[$_GET['provider']];
+
+			// Get user data to check if they have the requested link
+			$userData = $GLOBALS['db']->fetch('SELECT ' . $definition['selectColumns'] . ' FROM users WHERE id = ? LIMIT 1', [$_GET['id']]);
 			if (!$userData) {
 				throw new Exception('User not found');
 			}
 
-			if (empty($userData['discord_account_id'])) {
-				throw new Exception('User does not have a Discord link to reset');
+			if (empty($userData[$definition['idColumn']])) {
+				throw new Exception('User does not have a ' . $definition['label'] . ' link to reset');
 			}
 
-			// Reset the Discord link
-			$GLOBALS['db']->execute('UPDATE users SET discord_account_id = NULL WHERE id = ? LIMIT 1', [$_GET['id']]);
+			// Reset the requested connection link
+			$GLOBALS['db']->execute($definition['updateSql'], [$_GET['id']]);
 
 			// Rap log
-			postWebhookMessage(sprintf("has reset [%s](https://akatsuki.gg/u/%s)'s Discord link\n\n> :bust_in_silhouette: [View this user](https://old.akatsuki.gg/index.php?p=103&id=%s) on **Admin Panel**", $userData['username'], $_GET['id'], $_GET['id']));
-			rapLog(sprintf("has reset %s's Discord link", $userData['username']));
+			postWebhookMessage(sprintf("has reset [%s](https://akatsuki.gg/u/%s)'s %s link\n\n> :bust_in_silhouette: [View this user](https://old.akatsuki.gg/index.php?p=103&id=%s) on **Admin Panel**", $userData['username'], $_GET['id'], $definition['label'], $_GET['id']));
+			rapLog(sprintf("has reset %s's %s link", $userData['username'], $definition['label']));
 
 			// Done, redirect to success page
-			redirect('index.php?p=103&id=' . $_GET['id'] . '&s=Discord link reset!');
+			redirect('index.php?p=103&id=' . $_GET['id'] . '&s=' . $definition['label'] . ' link reset!');
 		} catch (Exception $e) {
 			// Redirect to Exception page
 			redirect('index.php?p=103&id=' . ($_GET['id'] ?? '') . '&e=' . $e->getMessage());

--- a/inc/Print.php
+++ b/inc/Print.php
@@ -735,6 +735,7 @@ class P
 						</tr>
 					</thead>
 					<tbody>';
+			$resetConnectionLinkURL = 'submit.php?action=resetConnectionLink&id=' . $_GET['id'] . '&csrf=' . csrfToken() . '&provider=';
 
 			echo '<tr>
 				<td><i class="fa fa-comments-o"></i> Discord</td>
@@ -746,7 +747,7 @@ class P
 					Discord ID ' . $discordAccountID . '<br>
 					<a href="https://discord.com/users/' . $discordAccountID . '" target="_blank" rel="noopener noreferrer">View profile</a>
 				</td>
-				<td><a onclick="sure(\'submit.php?action=resetDiscordLink&id=' . $_GET['id'] . '&csrf=' . csrfToken() . '\')">Reset link</a></td>';
+				<td><a onclick="sure(\'' . $resetConnectionLinkURL . 'discord\')">Reset link</a></td>';
 			} else {
 				echo '<span class="label label-danger">Not linked</span></td>
 				<td><em>No Discord account linked</em></td>
@@ -770,7 +771,7 @@ class P
 					echo '<br><a href="https://www.twitch.tv/' . rawurlencode($userData['twitch_username']) . '" target="_blank" rel="noopener noreferrer">View profile</a>';
 				}
 				echo '</td>
-				<td>-</td>';
+				<td><a onclick="sure(\'' . $resetConnectionLinkURL . 'twitch\')">Reset link</a></td>';
 			} else {
 				echo '<span class="label label-danger">Not linked</span></td>
 				<td><em>No Twitch account linked</em></td>
@@ -792,7 +793,7 @@ class P
 				echo 'osu! ID ' . $officialOsuUserID . '<br>
 					<a href="https://osu.ppy.sh/users/' . $officialOsuUserID . '" target="_blank" rel="noopener noreferrer">View profile</a>
 				</td>
-				<td>-</td>';
+				<td><a onclick="sure(\'' . $resetConnectionLinkURL . 'osu\')">Reset link</a></td>';
 			} else {
 				echo '<span class="label label-danger">Not linked</span></td>
 				<td><em>No osu! account linked</em></td>

--- a/submit.php
+++ b/submit.php
@@ -119,8 +119,13 @@ try {
 			D::ResetAvatar();
 			break;
 		case 'resetDiscordLink':
+			$_GET['provider'] = 'discord';
 			sessionCheckAdmin(Privileges::AdminManageUsers);
-			D::ResetDiscordLink();
+			D::ResetConnectionLink();
+			break;
+		case 'resetConnectionLink':
+			sessionCheckAdmin(Privileges::AdminManageUsers);
+			D::ResetConnectionLink();
 			break;
 		case 'wipeAccount':
 			sessionCheckAdmin(Privileges::AdminWipeUsers);

--- a/submit.php
+++ b/submit.php
@@ -118,11 +118,6 @@ try {
 			sessionCheckAdmin(Privileges::AdminManageUsers);
 			D::ResetAvatar();
 			break;
-		case 'resetDiscordLink':
-			$_GET['provider'] = 'discord';
-			sessionCheckAdmin(Privileges::AdminManageUsers);
-			D::ResetConnectionLink();
-			break;
 		case 'resetConnectionLink':
 			sessionCheckAdmin(Privileges::AdminManageUsers);
 			D::ResetConnectionLink();


### PR DESCRIPTION
## Summary
- replace the Discord-only reset handler with a provider-aware connected profile unlink handler
- add Reset link actions for Twitch and osu! connected profiles
- keep the old resetDiscordLink action as a Discord compatibility alias

## Verification
- php -l inc/Do.php
- php -l inc/Print.php
- php -l submit.php
- git diff --check